### PR TITLE
fix: raise OpenClaw report maxTokens to 8192 to prevent mid-sentence truncation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ async function generateSummaries(
       }
       console.log(`  [openclaw] Calling LLM for OpenClaw report...`);
       try {
-        return await callLlm(buildPeerPrompt(cfg, issues, prs, releases, dateStr, 50, 30, lang));
+        return await callLlm(buildPeerPrompt(cfg, issues, prs, releases, dateStr, 50, 30, lang), 8192);
       } catch (err) {
         console.error(`  [openclaw] LLM call failed: ${err}`);
         return summaryFailed;


### PR DESCRIPTION
## Problem

The OpenClaw deep-dive report gets truncated mid-sentence on high-activity days (e.g. #195):

> 今日 OpenClaw 项目展现出极高的工程迭代效率与社区活跃度。**过去**

Sentence cuts off at "过去"; the comparison section even notes "由于今日 OpenClaw 的原始数据源在提取时意外截断".

## Root cause

OpenClaw consumes the **largest input** (issues+prs+releases, often 900+ items) but calls `callLlm` with the **default `maxTokens=4096`` — smaller than every other report:

| Report | maxTokens | Input |
|---|---|---|
| trending | 6144 | small |
| web | 8192 | medium |
| **OpenClaw** | **4096 (default)** | **largest** |

Output hits `finish_reason=length` mid-report and the truncated text is written to the issue.

## Fix

Pass `8192` explicitly (`src/index.ts`), matching the web report:

```diff
- return await callLlm(buildPeerPrompt(cfg, issues, prs, releases, dateStr, 50, 30, lang));
+ return await callLlm(buildPeerPrompt(cfg, issues, prs, releases, dateStr, 50, 30, lang), 8192);
```

Co-Authored-By: Claude <noreply@anthropic.com>